### PR TITLE
Change compilation settings to only do x86 and hide unnecessary COM object

### DIFF
--- a/src/OGRPlugin/OGRPlugin.sln
+++ b/src/OGRPlugin/OGRPlugin.sln
@@ -1,28 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual C# Express 2010
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OGRPlugin", "OGRPlugin\OGRPlugin.csproj", "{0B5AB20C-1A09-48F0-8164-333747A148ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|x86.ActiveCfg = Debug|x86
+		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Debug|x86.Build.0 = Debug|x86
 		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|x86.ActiveCfg = Release|x86
+		{0B5AB20C-1A09-48F0-8164-333747A148ED}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OGRPlugin/OGRPlugin/OGRAddLayerDialog.cs
+++ b/src/OGRPlugin/OGRPlugin/OGRAddLayerDialog.cs
@@ -13,6 +13,7 @@ using ESRI.ArcGIS.Geodatabase;
 
 namespace GDAL.OGRPlugin
 {
+	[System.Runtime.InteropServices.ComVisible(false)]
     public partial class OGRAddLayerDialog : Form
     {
         #region class members

--- a/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj
+++ b/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj
@@ -56,6 +56,16 @@
     <RegisterForComInterop>true</RegisterForComInterop>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <RegisterForComInterop>true</RegisterForComInterop>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <RegisterForComInterop>true</RegisterForComInterop>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="ESRI.ArcGIS.ADF.Local, Version=10.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj.user
+++ b/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj.user
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishUrlHistory />
@@ -11,11 +11,14 @@
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-      <StartAction>Program</StartAction>
-      <StartProgram>C:\Program Files (x86)\ArcGIS\Desktop10.1\bin\ArcMap.exe</StartProgram>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-      <StartAction>Program</StartAction>
-      <StartProgram>C:\Program Files (x86)\ArcGIS\Desktop10.1\bin\ArcMap.exe</StartProgram>
-   </PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files (x86)\ArcGIS\Desktop10.1\bin\ArcMap.exe</StartProgram>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files (x86)\ArcGIS\Desktop10.1\bin\ArcMap.exe</StartProgram>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ReferencePath>C:\Users\dani3589\Documents\GitHub\arcgis-ogr\src\OGRPlugin\OGRPlugin\lib\gdal-csharp\</ReferencePath>
+  </PropertyGroup>
 </Project>

--- a/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj.user
+++ b/src/OGRPlugin/OGRPlugin/OGRPlugin.csproj.user
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishUrlHistory />
@@ -19,6 +19,6 @@
     <StartProgram>C:\Program Files (x86)\ArcGIS\Desktop10.1\bin\ArcMap.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup>
-    <ReferencePath>C:\Users\dani3589\Documents\GitHub\arcgis-ogr\src\OGRPlugin\OGRPlugin\lib\gdal-csharp\</ReferencePath>
+    <ReferencePath></ReferencePath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changed project settings to compile for x86 only, also removed the com
visibility of OGRAddLayerDialog as it's not a com object.
