### PR TITLE
Flattening geometries to 2D before converting them to Esri geometry via WKB

### DIFF
--- a/src/OGRPlugin/OGRPlugin/OGRCursor.cs
+++ b/src/OGRPlugin/OGRPlugin/OGRCursor.cs
@@ -165,6 +165,11 @@ namespace GDAL.OGRPlugin
             {
                 OSGeo.OGR.Geometry ogrGeometry = m_currentOGRFeature.GetGeometryRef();
 
+                // It seems that the IWkb.ImportFromWkb called below has trouble with Z values.
+                // Will need to investigate this further, but as a quick fix, we flatten
+                // the geometry prior to conversion.
+                ogrGeometry.FlattenTo2D();
+
                 //export geometry from OGR to WKB
                 int wkbSize = ogrGeometry.WkbSize();
                 byte[] wkbBuffer = new byte[wkbSize];


### PR DESCRIPTION
Quick workaround for issues with Z-enabled coordinates. Probably not a definitive solution.

Also tried IGeometryFactory.CreateGeometryFromWkbVariant, which does not work either (gives exception: "wkb type is not one of point, multipoint, linestring, multilinestring, polygon, multipolygon, multipatch or geometrycollection").

If it is confirmed that IWkb.ImportFromWkb cannot handle Z coordinates, we'll have to find an alternative way of converting geometries to Esri, perhaps by reimplementing the WKB conversion altogether.
